### PR TITLE
Use Now 0 config for “next export”

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,12 +1,6 @@
 {
   "version": 2,
   "name": "octolinker-site",
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@now/static-build"
-    }
-  ],
   "alias": [
     "octolinker.now.sh"
   ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "next dev",
-    "now-build": "next build && next export -o dist"
+    "build": "next build && next export"
   },
   "dependencies": {
     "bowser": "^2.7.0",


### PR DESCRIPTION
This automatically configures the right caching headers (currently missing) and requires no custom configuration.