### PR TITLE
docs: Use the api repository url

### DIFF
--- a/components/howItWorks.js
+++ b/components/howItWorks.js
@@ -58,7 +58,7 @@ export default function HowItWorks() {
           <p>
             Relative file references are resolved through the GitHub tree API in
             your browser. External dependencies are resolved using the{" "}
-            <a href="https://octolinker.now.sh/">OctoLinker API</a>.{" "}
+            <a href="https://github.com/OctoLinker/api">OctoLinker API</a>.{" "}
           </p>
           <p>
             Only the name of a dependency along with the registry type is sent


### PR DESCRIPTION
Perhaps it's a typo of using the homepage as the API URL. By changing it to the api repo's URL, it can guide users to the repo to know how the API actually works.